### PR TITLE
Only warn if no rows found

### DIFF
--- a/chado/lib/Bio/GMOD/DB/Adapter.pm
+++ b/chado/lib/Bio/GMOD/DB/Adapter.pm
@@ -1506,7 +1506,9 @@ sub initialize_ontology {
     $sth->execute;
     ($part_of) = $sth->fetchrow_array();
 
-    warn "\n\nWARNING:\nUnable to find a 'part_of' term in the relationship ontology;\nIt's absense indicates that there is something really wrong with the database.\nConsider stopping and checking the state of your cvterm table.\n\n\n";
+    if ($sth->rows == 0) {
+        warn "\n\nWARNING:\nUnable to find a 'part_of' term in the relationship ontology;\nIt's absense indicates that there is something really wrong with the database.\nConsider stopping and checking the state of your cvterm table.\n\n\n";
+    }
 
 
     $sth = $self->dbh->prepare(


### PR DESCRIPTION
I ran into [this](http://generic-model-organism-system-database.450254.n5.nabble.com/Unable-to-find-a-part-of-term-in-the-relationship-ontology-td5712524.html) error and after checking that my schema was OK (returned a cvterm id for part_of from RO and PO), debugged and found that this warning was issued unconditionally. This patch corrects that and only warns if no rows are found.