### PR TITLE
Project stock biomaterial linker tables

### DIFF
--- a/chado/modules/project/project.sql
+++ b/chado/modules/project/project.sql
@@ -13,6 +13,7 @@
 -- :import analysis from companalysis
 -- :import feature from sequence
 -- :import stock from stock
+-- :import biomaterial from mage
 -- =================================================================
 
 
@@ -25,6 +26,8 @@ create table project (
     primary key (project_id),
     name varchar(255) not null,
     description text,
+    type_id bigint NOT NULL,
+	FOREIGN KEY (type_id) REFERENCES cvterm (cvterm_id) ON DELETE CASCADE,
     constraint project_c1 unique (name)
 );
 
@@ -187,3 +190,23 @@ CREATE INDEX project_stock_idx2 ON project_stock USING btree (project_id);
 
 
 COMMENT ON TABLE project_stock IS 'This table is intended associate records in the stock table with a project.';
+
+-- ================================================
+-- TABLE: biomaterial_project
+-- ================================================
+
+
+CREATE TABLE biomaterial_project (
+    biomaterial_project_id bigserial primary key NOT NULL,
+    biomaterial_id bigint NOT NULL,
+    project_id bigint NOT NULL,
+    CONSTRAINT biomaterial_project_c1 UNIQUE (biomaterial_id, project_id),
+    FOREIGN KEY (biomaterial_id) REFERENCES biomaterial(biomaterial_id) ON DELETE CASCADE,
+    FOREIGN KEY (project_id) REFERENCES project(project_id) ON DELETE CASCADE
+);
+
+CREATE INDEX biomaterial_project_idx1 ON biomaterial_project USING btree (biomaterial_id);
+CREATE INDEX biomaterial_project_idx2 ON biomaterial_project USING btree (project_id);
+
+
+COMMENT ON TABLE project_stock IS 'This table is intended associate records in the biomaterial table with a project.';

--- a/chado/modules/stock/stock.sql
+++ b/chado/modules/stock/stock.sql
@@ -12,6 +12,7 @@
 -- :import contact from contact
 -- :import feature from sequence
 -- :import featuremap from map
+-- :import biomaterial from mage
 -- ================================================
 -- TABLE: stock
 -- ================================================
@@ -462,3 +463,21 @@ CREATE INDEX stock_library_idx2 ON stock_library USING btree (stock_id);
 
 COMMENT ON TABLE stock_library IS 'Links a stock with a library.';
 
+
+
+-- ================================================
+-- TABLE: stock_biomaterial
+-- ================================================
+CREATE TABLE stock_biomaterial (
+    stock_biomaterial_id bigserial primary key NOT NULL,
+    biomaterial_id bigint NOT NULL,
+    stock_id bigint NOT NULL,
+    CONSTRAINT stock_biomaterial_c1 UNIQUE (biomaterial_id, stock_id),
+    FOREIGN KEY (biomaterial_id) REFERENCES biomaterial(biomaterial_id) ON DELETE CASCADE,
+    FOREIGN KEY (stock_id) REFERENCES stock(stock_id) ON DELETE CASCADE
+);
+
+CREATE INDEX stock_biomaterial_idx1 ON stock_biomaterial USING btree (biomaterial_id);
+CREATE INDEX stock_biomaterial_idx2 ON stock_biomaterial USING btree (stock_id);
+
+COMMENT ON TABLE stock_biomaterial IS 'Associates records in the biomaterial table with a stock.';


### PR DESCRIPTION
Add two new self explanatory linker tables: biomaterial_project,
stock_biomaterial.  Add a type_id to project.  These changes were made
instead of adding foreign keys to the table.   See issue #41 

Note I added the linker table orders as written- I wasn't sure if it reflected heirarchy or the module it was from etc...