### PR TITLE
write migration for uniquename constraint (migration V1.3.3.003)

### DIFF
--- a/chado/migrations/V1.3.3.003__alter_analysis_unique_constraint.sql
+++ b/chado/migrations/V1.3.3.003__alter_analysis_unique_constraint.sql
@@ -1,0 +1,3 @@
+ALTER TABLE analysis
+  DROP CONSTRAINT analysis_c1
+, ADD  CONSTRAINT analysis_c1 unique (program,programversion, name, sourcename);


### PR DESCRIPTION
resolve #40

we drop and add the constraint analysis_c1 adding uniquename to the constraint. This is a backwards compatible way of allowing analyses to share a program, programversion, and sourcename.