### PR TITLE
Build schemaspy documentation continuously and host on RTD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ jdk:
 services:
   - postgresql
 
+env:
+  global:
+    - GH_REF: https://github.com/GMOD/Chado.git
+
 matrix:
   include:
     - addons:
@@ -20,3 +24,25 @@ script:
   - gradle flywayInfo
   - gradle flywayMigrate
   - gradle flywayInfo
+
+after_success:
+# build the schemaspy documentation
+  - git checkout rtd
+  - git clone https://github.com/laceysanderson/chado-docs.git
+  - curl -L https://github.com/schemaspy/schemaspy/releases/download/v6.0.0/schemaspy-6.0.0.jar > ./schemaspy-6.0.0.jar
+  - curl https://jdbc.postgresql.org/download/postgresql-42.2.5.jar > ./postgres_driver.jar
+  - cd chado-docs
+  - ./build/build_docs.sh -d postgres -u postgres -p '' -s ../schemaspy-6.0.0.jar -g ../postgres_driver.jar -c ../
+  - cd ..
+  - rm -rf docs/_static/schemaspy_integration
+  - mv chado-docs docs/_static/schemaspy_integration
+
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN
+  keep-history: true
+  on:
+    branch: 1.4
+    #change above to master once we're off 1.4 dev branch
+  target-branch: rtd

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Chado is a relational database schema that underlies many GMOD installations. It
   installation
   modules
   best_practices
+  schema_definition
 
 
 Mailing List

--- a/docs/schema_definition.rst
+++ b/docs/schema_definition.rst
@@ -1,4 +1,4 @@
 Schema
 =======
 
-`You can browse the full schema here.<_static/schemaspy_integration/index.html>`_
+`You can browse the full schema here.<_static/schemaspy_integration/index.html>`_ . This documentation includes table definitions, comments, constraints, and indices.

--- a/docs/schema_definition.rst
+++ b/docs/schema_definition.rst
@@ -1,0 +1,4 @@
+Schema
+=======
+
+`You can browse the full schema here.<_static/schemaspy_integration/index.html>`_


### PR DESCRIPTION
This pr closes the circle on #36 

Here's what happens:

- Travis runs schemaspy script as written by @laceysanderson  to build a website based on the most recent schema version, grouped by Chado module
   - i just clone that repo.  We could simply include the build script in this repo instead, but IMO deal with this one step at a time and do that later.
- Copy said website into the `_static` folder of the documentation
- Merge event on branch 1.4  (we'll change to master once we're off the `1.4` dev branch) triggers pushing the built documentation to the `rtd` branch
- Readthedocs is now set up to build when changes occur on `rtd` branch


You can find the CI-built schemaspy site here: https://chado.readthedocs.io/en/rtd/_static/schemaspy_integration/index.html


### improvements?
We currenty build the schemaspy website on all branches.  that might be a good thing?  But if we only want to build it when we're going to deploy it, we could stick it all in a script and add this to the top:

```
#!/bin/bash
if [ "$TRAVIS_BRANCH" == "1.4" ]; then
  // do the deploy
fi
```

we also probably need to add a link back to the main documentation website in the schemaspy site.