### PR TITLE
fix typo in link to schemaspy

### DIFF
--- a/docs/schema_definition.rst
+++ b/docs/schema_definition.rst
@@ -1,4 +1,4 @@
 Schema
 =======
 
-`You can browse the full schema here.<_static/schemaspy_integration/index.html>`_ . This documentation includes table definitions, comments, constraints, and indices.
+`You can browse the full schema here <_static/schemaspy_integration/index.html>`_. This documentation includes table definitions, comments, constraints, and indices.


### PR DESCRIPTION
The link to the schema page is broken.  This fixes it

![Screen Shot 2019-03-21 at 9 16 27 PM](https://user-images.githubusercontent.com/7063154/54794619-b9b6b700-4c1e-11e9-8f8e-3c759cf0a9d3.png)

![Screen Shot 2019-03-21 at 9 16 36 PM](https://user-images.githubusercontent.com/7063154/54794621-bc191100-4c1e-11e9-83e6-b2a6190fc3d7.png)


Its live here:  https://chado.readthedocs.io/en/rtd/schema_definition.html

And it [should link here](https://chado.readthedocs.io/en/rtd/_static/schemaspy_integration/index.html), but doesnt.  I guess RST doesnt allow a period in the link name?

This is a minor patch to #101