### PR TITLE
Fix for search_path issue in #65 (migration V1.3.3.007)

### DIFF
--- a/chado/migrations/V1.3.3.007__fix_search_path.sql
+++ b/chado/migrations/V1.3.3.007__fix_search_path.sql
@@ -1,0 +1,58 @@
+/*
+ * Set the search_path to the current_schema
+ * so that we can use SET SEARCH_PATH FROM CURRENT
+ * in function definitions.
+ * 
+ * This fix addresses a problem that was introduced
+ * by [CVE-2018-1058](https://nvd.nist.gov/vuln/detail/CVE-2018-1058).
+ *
+ * https://github.com/GMOD/Chado/issues/65
+ *
+ */
+SELECT set_config('search_path',
+  string_agg(quote_ident(s),','),
+  false)
+FROM unnest(current_schemas(false)) s;
+
+CREATE OR REPLACE FUNCTION fill_cvtermpath(INTEGER) RETURNS INTEGER AS
+'
+DECLARE
+    cvid alias for $1;
+    root cvterm%ROWTYPE;
+
+BEGIN
+
+    DELETE FROM cvtermpath WHERE cv_id = cvid;
+
+    FOR root IN SELECT DISTINCT t.* from cvterm t LEFT JOIN cvterm_relationship r ON (t.cvterm_id = r.subject_id) INNER JOIN cvterm_relationship r2 ON (t.cvterm_id = r2.object_id) WHERE t.cv_id = cvid AND r.subject_id is null LOOP
+        PERFORM _fill_cvtermpath4root(root.cvterm_id, root.cv_id);
+    END LOOP;
+    RETURN 1;
+END;
+'
+LANGUAGE 'plpgsql' SET SEARCH_PATH FROM CURRENT;
+
+CREATE OR REPLACE FUNCTION fill_cvtermpath(cv.name%TYPE) RETURNS INTEGER AS
+'
+DECLARE
+    cvname alias for $1;
+    cv_id   int;
+    rtn     int;
+BEGIN
+
+    SELECT INTO cv_id cv.cv_id from cv WHERE cv.name = cvname;
+    SELECT INTO rtn fill_cvtermpath(cv_id);
+    RETURN rtn;
+END;
+'
+LANGUAGE 'plpgsql' SET SEARCH_PATH FROM CURRENT;
+
+-- create a range box
+-- (make this immutable so we can index it)
+CREATE OR REPLACE FUNCTION boxrange (bigint, bigint) RETURNS box AS
+ 'SELECT box (create_point(CAST(0 AS bigint), $1), create_point($2,500000000))'
+LANGUAGE 'sql' IMMUTABLE SET SEARCH_PATH FROM CURRENT;
+
+CREATE OR REPLACE FUNCTION boxrange (bigint, bigint, bigint) RETURNS box AS
+ 'SELECT box (create_point($1, $2), create_point($1,$3))'
+LANGUAGE 'sql' IMMUTABLE SET SEARCH_PATH FROM CURRENT;


### PR DESCRIPTION
# Bug Fix

Issue #65 

## Description

This fix address a problem that was introduced
by [CVE-2018-1058](https://nvd.nist.gov/vuln/detail/CVE-2018-1058).

## Testing

On PostgreSQL 9.3+ run the following command.

### Failure without patch
```
> vacuumdb -f -v -z -t featureloc DBNAME`
vacuumdb: vacuuming database "DBNAME"
INFO:  vacuuming "public.featureloc"
INFO:  "featureloc": found 0 removable, 0 nonremovable row versions in 0 pages
DETAIL:  0 dead row versions cannot be removed yet.
CPU: user: 0.01 s, system: 0.01 s, elapsed: 0.02 s.
vacuumdb: vacuuming of table "featureloc" in database "DBNAME" failed: ERROR:  function create_point(bigint, bigint) does not exist
LINE 1: SELECT box (create_point(CAST(0 AS bigint), $1), create_poin...
                    ^
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
QUERY:  SELECT box (create_point(CAST(0 AS bigint), $1), create_point($2,500000000))
CONTEXT:  SQL function "boxrange" during inlining
```

### Works with patch
```
> vacuumdb -f -v -z -t featureloc DBNAME`
vacuumdb: vacuuming database "DBNAME"
INFO:  vacuuming "public.featureloc"
INFO:  "featureloc": found 0 removable, 0 nonremovable row versions in 0 pages
DETAIL:  0 dead row versions cannot be removed yet.
CPU: user: 0.02 s, system: 0.00 s, elapsed: 0.02 s.
INFO:  analyzing "public.featureloc"
INFO:  "featureloc": scanned 0 of 0 pages, containing 0 live rows and 0 dead rows; 0 rows in sample, 0 estimated total rows
```

