### PR TITLE
Adding is_obsolete to cell_line table (V1.3.3.008)

### DIFF
--- a/chado/migrations/V1.3.3.008__add_is_obsolete_cell_line_table.sql
+++ b/chado/migrations/V1.3.3.008__add_is_obsolete_cell_line_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cell_line ADD COLUMN is_obsolete boolean DEFAULT false;


### PR DESCRIPTION
This PR adds an `is_obsolete` column to the cell_line table to address #110.